### PR TITLE
Support multipart/mixed

### DIFF
--- a/lib/email_send_patch.rb
+++ b/lib/email_send_patch.rb
@@ -23,14 +23,22 @@ class InlineImagesEmailInterceptor
         $1 << attachment_url << $3
       end
 
+      alt_parts = message.parts
+      message.parts.each do |part|
+        if part.content_type.starts_with?('multipart/alternative')
+          alt_parts = part.parts
+          break
+        end
+      end
+
       # multipart/alternative
       # - text/plain
       # - multipart/relative
       # -- text/html
       # -- image/*
-      message.parts.clear
-      message.parts << text_part
-      message.parts << related
+      alt_parts.clear
+      alt_parts << text_part
+      alt_parts << related
     end
   end
 end


### PR DESCRIPTION
If this plugin, is installed along with, e.g., [Issue Mail With Attachments](https://github.com/team888/redmine-issue_mail_with_attachments-plugin,) it damages email notifications (when they include attachments). This happens because it does not check, if the email is `multipart/alternative` and always reformats it as it was such. In this way, `multipart/mixed` emails get text, HTML and attachment parts as its top-level parts. As a result, email clients (such as Thunderbird) can show both parts - text and HTML ones - for such damaged emails.