### PR TITLE
Fix attachment not inlined on redmine 5.0.5

### DIFF
--- a/lib/email_send_patch.rb
+++ b/lib/email_send_patch.rb
@@ -14,7 +14,7 @@ class EmailSendPatch
       html_part.body = html_part.body.to_s.gsub(FIND_IMG_SRC_PATTERN) do
         image_url = $2
         attachment_url = image_url
-        attachment_object = Attachment.where(:id => Pathname.new(image_url).dirname.basename.to_s).first
+        attachment_object = Attachment.where(:id => Pathname.new(image_url).basename.to_s).first
         if attachment_object
           image_name = attachment_object.filename
           related.attachments.inline[image_name] = File.read(attachment_object.diskfile)


### PR DESCRIPTION
Images where not added on my redmine 5.0.5 installation.
After debugging, i found that the attachment with url "https://XXXX/attachments/download/1294" was searched an id with "download".

After the change it's using the filename which is 1294 -> and the id.
And of course it's working.