### PR TITLE
Fix image loading and add thumbnail support

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 require 'htmlentities'
 coder = HTMLEntities.new
-FIND_IMG_SRC_PATTERN = /(<img[^>]+src=")((?:#{Setting.protocol + "://[^/]+" + Redmine::Utils.relative_url_root})[^"]+)("[^>]*>)/
+FIND_IMG_SRC_PATTERN = /(<img[^>]+src=")(?:#{Setting.protocol + "://[^/]+"})?#{Redmine::Utils.relative_url_root}([^"]+)("[^>]*>)/
 
 Redmine::Plugin.register :redmine_email_images do
   name 'Redmine Email Images plugin'

--- a/init.rb
+++ b/init.rb
@@ -1,6 +1,6 @@
 require 'htmlentities'
 coder = HTMLEntities.new
-FIND_IMG_SRC_PATTERN = /(<img[^>]+src=")(?:#{Setting.protocol + "://[^/]+"})?#{Redmine::Utils.relative_url_root}([^"]+)("[^>]*>)/
+FIND_IMG_SRC_PATTERN = /(<img[^>]+src=")(?:#{Setting.protocol + ":\d*//[^/]+"})?#{Redmine::Utils.relative_url_root}([^"]+)("[^>]*>)/
 
 Redmine::Plugin.register :redmine_email_images do
   name 'Redmine Email Images plugin'

--- a/lib/email_send_patch.rb
+++ b/lib/email_send_patch.rb
@@ -17,7 +17,7 @@ class EmailSendPatch
         attachment_object = Attachment.where(:id => Pathname.new(image_url).dirname.basename.to_s).first
         if attachment_object
           image_name = attachment_object.filename
-          related.attachments.inline[image_name] = File.read(attachment_object.diskfile)
+          related.attachments.inline[image_name] = File.binread(attachment_object.diskfile)
           attachment_url = related.attachments[image_name].url
         end
 

--- a/lib/email_send_patch.rb
+++ b/lib/email_send_patch.rb
@@ -16,7 +16,7 @@ class EmailSendPatch
         attachment_url = image_url
         attachment_object = Attachment.where(:id => Pathname.new(image_url).dirname.basename.to_s).first
         if attachment_object
-          image_name = attachment_object.filename
+          image_name = attachment_object.filename + "|" + SecureRandom.hex
           related.attachments.inline[image_name] = File.binread(attachment_object.diskfile)
           attachment_url = related.attachments[image_name].url
         end


### PR DESCRIPTION
This PR contains the following fixes and improvements:
- Fix image loading method: change `File.read` to `File.binread`
- Handle duplicate filenames
- Support URLs with port numbers
- Support URLs without protocol
- Add support for loading thumbnail images

I tested in two environments.
Environment 1:
```
Environment:
  Redmine version                5.1.4.stable
  Ruby version                   3.1.4-p223 (2023-03-30) [x64-mingw-ucrt]
  Rails version                  6.1.7.10
  Environment                    production
  Database adapter               Mysql2
  Mailer queue                   ActiveJob::QueueAdapters::AsyncAdapter
  Mailer delivery                smtp
```

Environment 2:
```
Environment:
  Redmine version                6.0.2.stable
  Ruby version                   3.2.6-p234 (2024-10-30) [x64-mingw-ucrt]
  Rails version                  7.2.2.1
  Environment                    production
  Database adapter               Mysql2
  Mailer queue                   ActiveJob::QueueAdapters::AsyncAdapter
  Mailer delivery                smtp
  ```